### PR TITLE
[0.2.14] - 2024-10-18

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.14] - 2024-10-18
+
+### Changed
+
+-   After refreshing a refresh token, the SDK now correctly retries the request even when there it consists of a single GraphQl query.
+
 ## [0.2.13] - 2024-10-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fanpoints/server-js",
-    "version": "0.2.13",
+    "version": "0.2.14",
     "description": "The SDK that allows to integrate FanPoints on the server-side.",
     "files": [
         "dist"

--- a/src/FanPointsClient.ts
+++ b/src/FanPointsClient.ts
@@ -74,7 +74,9 @@ export default class FanPointsClient<PartnerLabel extends string = string> {
             ) {
                 await authSession.refreshToken();
                 return graphQLClient.rawRequest(
-                    response.request.query[0],
+                    Array.isArray(response.request.query)
+                        ? response.request.query[0]
+                        : response.request.query,
                     response.request.variables,
                 );
             }


### PR DESCRIPTION
### Changed

-   After refreshing a refresh token, the SDK now correctly retries the request even when there it consists of a single GraphQl query.