### PR TITLE
[0.2.23] - 2024-11-15

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.23] - 2024-11-15
+
+### Changed
+
+-   The build scripts were changed to explicitly name the ESM module as `index.mjs` to allow Vercel to correctly use the ESM module instead of the CJS module.
+
 ## [0.2.20] - 2024-11-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
     "name": "@fanpoints/server-js",
-    "version": "0.2.22",
+    "version": "0.2.23",
     "description": "The SDK that allows to integrate FanPoints on the server-side.",
     "files": [
         "dist"
     ],
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "main": "dist/cjs/index.js",
     "exports": {
         ".": {
-            "import": "./dist/esm/index.js",
+            "import": "./dist/esm/index.mjs",
             "require": "./dist/cjs/index.js",
             "types": "./dist/index.d.ts"
         }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ export default [
         input: 'src/index.ts',
         output: [
             {
-                dir: 'dist/esm',
+                file: 'dist/esm/index.mjs',
                 format: 'esm',
             },
         ],


### PR DESCRIPTION
### Changed

-   The build scripts were changed to explicitly name the ESM module as `index.mjs` to allow Vercel to correctly use the ESM module instead of the CJS module.